### PR TITLE
Improve floating point numbers support

### DIFF
--- a/Playground/Controllers/HomeController.cs
+++ b/Playground/Controllers/HomeController.cs
@@ -66,5 +66,8 @@ namespace Playground.Controllers
         
         [RemoteUiField("ListOfObjects")]
         public List<DtoBase> ListOfObjects { get; set; }
+        
+        [RemoteUiField("Some float")]
+        public decimal SomeFloat { get; set; }
     }
 }

--- a/RemoteUi/web/src/RemoteUiEditorStore.ts
+++ b/RemoteUi/web/src/RemoteUiEditorStore.ts
@@ -298,10 +298,18 @@ export class RemoteUiTextInputStore implements IRemoteUiData {
         else if (this._type == PredefinedTypes.Number) {
             try {
                 const parsed = parseFloat(value);
-                if (isNaN(parsed))
+                if (isNaN(parsed)) {
                     this.value = '';
-                else
+                } else if (value.endsWith('.')) {
+                    const dots = value.match(/\./g) || [];
+                    if (dots.length <= 1) {
+                        this.value = parsed.toString() + '.';
+                    } else {
+                        this.value = parsed.toString();
+                    }
+                } else {
                     this.value = parsed.toString();
+                }
             }
             catch {
 


### PR DESCRIPTION
Users are unable to type `0.` and similar values into text boxes generated for `PredefinedTypes.Number` properties. This pull request fixes the described issue by adding a dot to output if there are no dots yet in a provided string for properties with `PredefinedTypes.Number` type.