### PR TITLE
Detect more types automatically

### DIFF
--- a/RemoteUi/RemoteUi.cs
+++ b/RemoteUi/RemoteUi.cs
@@ -299,9 +299,13 @@ namespace RemoteUi
                         type = RemoteUiFieldType.Integer;
                         nullable = true;
                     }
-                    else if (ptype == typeof(decimal))
+                    else if (ptype == typeof(decimal) ||
+                             ptype == typeof(float) ||
+                             ptype == typeof(double))
                         type = RemoteUiFieldType.Number;
-                    else if (ptype == typeof(decimal?))
+                    else if (ptype == typeof(decimal?) ||
+                             ptype == typeof(float?) ||
+                             ptype == typeof(double?))
                     {
                         type = RemoteUiFieldType.Number;
                         nullable = true;

--- a/RemoteUi/RemoteUi.cs
+++ b/RemoteUi/RemoteUi.cs
@@ -290,8 +290,15 @@ namespace RemoteUi
                         type = RemoteUiFieldType.String;
                     else if (typeof(IEnumerable<string>).IsAssignableFrom(ptype))
                         type = RemoteUiFieldType.StringList;
-                    else if (ptype == typeof(int))
+                    else if (ptype == typeof(int) ||
+                             ptype == typeof(long))
                         type = RemoteUiFieldType.Integer;
+                    else if (ptype == typeof(int?) ||
+                             ptype == typeof(long?))
+                    {
+                        type = RemoteUiFieldType.Integer;
+                        nullable = true;
+                    }
                     else if (ptype == typeof(decimal))
                         type = RemoteUiFieldType.Number;
                     else if (ptype == typeof(decimal?))


### PR DESCRIPTION
Adds support for `long`, `int?` and `long?` types treating them as `RemoteUiFieldType.Integer`; also for `float`, `double`, `float?`, `double?` treating them as `RemoteUiFieldType.Number`s.