### PR TITLE
Id naming strategy override

### DIFF
--- a/Playground/Controllers/HomeController.cs
+++ b/Playground/Controllers/HomeController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 using RemoteUi;
 
 namespace Playground.Controllers
@@ -16,7 +17,7 @@ namespace Playground.Controllers
         private RemoteUiBuilder _info;
         public HomeController()
         {
-            _info = new RemoteUiBuilder(typeof(Dto), null).Register(typeof(DtoBase), null, "Test");
+            _info = new RemoteUiBuilder(typeof(Dto), null, null, new SnakeCaseNamingStrategy()).Register(typeof(DtoBase), null, "Test");
         }
         [HttpGet("")]
         public IActionResult Index()
@@ -28,7 +29,7 @@ namespace Playground.Controllers
         public object GetDescription() => _info.Build(null);
 
         [HttpGet("initial")]
-        public object GetObject() => new JsonResult(new Dto(), _info.GetSerializerSettings());
+        public object GetObject() => new JsonResult(new Dto() { SomeString = "Sample Text" }, _info.GetSerializerSettings());
 
         [HttpPost("validate")]
         public object Validate([FromBody] Dto data)

--- a/RemoteUi/RemoteUi.cs
+++ b/RemoteUi/RemoteUi.cs
@@ -196,6 +196,7 @@ namespace RemoteUi
         private readonly IEnumerable<IExtraRemoteUiField> _rootExtraFields;
         private readonly Func<string, string> _displayTransform;
         private readonly Type _root;
+        private readonly NamingStrategy _namingStrategy;
 
         class FieldGroup
         {
@@ -210,12 +211,12 @@ namespace RemoteUi
             new List<(Type type, IEnumerable<IExtraRemoteUiField> fields)>();
 
         public RemoteUiBuilder(Type root, 
-            IEnumerable<IExtraRemoteUiField> extraFields, 
-            Func<string, string> displayTransform = null)
+            IEnumerable<IExtraRemoteUiField> extraFields, Func<string, string> displayTransform = null, NamingStrategy namingStrategy = null)
         {
             _root = root;
             _rootExtraFields = extraFields;
             _displayTransform = displayTransform;
+            _namingStrategy = namingStrategy ?? new DefaultNamingStrategy();
         }
 
         public RemoteUiBuilder Register(Type type, IEnumerable<IExtraRemoteUiField> fields, string name = null)
@@ -245,7 +246,7 @@ namespace RemoteUi
                 .Where(x => x.fields != null)
                 .ToDictionary(t => t.type, t => t.fields?.ToList() ?? new List<IExtraRemoteUiField>());
             dic[_root] = _rootExtraFields?.ToList() ?? new List<IExtraRemoteUiField>();
-            return new ContractResolver(dic);
+            return new ContractResolver(dic) {NamingStrategy = _namingStrategy};
         }
         
         public JsonSerializerSettings GetSerializerSettings() => new JsonSerializerSettings()

--- a/RemoteUi/RemoteUi.cs
+++ b/RemoteUi/RemoteUi.cs
@@ -255,7 +255,7 @@ namespace RemoteUi
             Converters = {new StringEnumConverter()}
         };
 
-        static JObject Get(
+        private JObject Get(
             IServiceProvider services, Type typee, 
             Dictionary<Type, string> typeRegistry,
             IEnumerable<IExtraRemoteUiField> extraFields,
@@ -264,7 +264,7 @@ namespace RemoteUi
             var groups = typee.GetCustomAttributes<RemoteUiFieldGroup>()
                 .Select(x => new FieldGroup
                 {
-                    Id = x.Id,
+                    Id = _namingStrategy.GetPropertyName(x.Id, false),
                     Name = x.Name
                 }).ToList();
 
@@ -350,7 +350,7 @@ namespace RemoteUi
                 var field = new JObject
                 {
                     ["name"] = name,
-                    ["id"] = prop.Name,
+                    ["id"] = _namingStrategy.GetPropertyName(prop.Name, false),
                     ["type"] = type.ToString(),
                     ["description"] = description,
                     ["alwaysExpanded"] = attr?.AlwaysExpanded == true
@@ -372,7 +372,7 @@ namespace RemoteUi
                     {
                         lst.Add(new
                         {
-                            id = radioAttr.Id,
+                            id = _namingStrategy.GetPropertyName(radioAttr.Id, false),
                             name = radioAttr.Name
                         });
                     }
@@ -382,7 +382,7 @@ namespace RemoteUi
                         foreach (var kp in customAttr.Get(services))
                             lst.Add(new
                             {
-                                id = kp.Key,
+                                id = _namingStrategy.GetPropertyName(kp.Key, false),
                                 name = kp.Value
                             });
                     }
@@ -399,7 +399,7 @@ namespace RemoteUi
                     var grp = dic[extra.Group ?? ""];
                     var field = new JObject
                     {
-                        ["id"] = extra.Id,
+                        ["id"] = _namingStrategy.GetPropertyName(extra.Id, false),
                         ["name"] = extra.DisplayName,
                         ["type"] = extra.Type.ToString()
                     };
@@ -409,7 +409,7 @@ namespace RemoteUi
                         extra.Type.Equals(RemoteUiFieldType.Custom))
                         field["possibleValues"] = JToken.FromObject(extra.PossibleValues.Select(kp => new
                         {
-                            id = kp.Key,
+                            id = _namingStrategy.GetPropertyName(kp.Key, false),
                             name = kp.Value
                         }));
                     if (extra.Type.Equals(RemoteUiFieldType.List))


### PR DESCRIPTION
Allow override id naming rules via NamingStrategy property

Playground also extended to utilize feature