### PR TITLE
Id override via attribute

### DIFF
--- a/Playground/Controllers/HomeController.cs
+++ b/Playground/Controllers/HomeController.cs
@@ -62,6 +62,10 @@ namespace Playground.Controllers
         [RemoteUiField("List of strings")]
         public List<string> ListOfStrings { get; set; }
         
+        [RemoteUiField("Overided ID List", Id = "OverrideMe")]
+        [JsonProperty("OverrideMe")]
+        public List<string> OverrideList { get; set; } = new List<string>() { "123321" };
+        
         [RemoteUiField("SomeString")]
         public string SomeString { get; set; }
         

--- a/RemoteUi/RemoteUi.cs
+++ b/RemoteUi/RemoteUi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -28,6 +28,7 @@ namespace RemoteUi
     [AttributeUsage(AttributeTargets.Property)]
     public class RemoteUiField : Attribute
     {
+        public string Id { get; set; }
         public string Name { get; set; }
         public string Group { get; set; }
         public object Type { get; set; }
@@ -356,7 +357,9 @@ namespace RemoteUi
                     ["alwaysExpanded"] = attr?.AlwaysExpanded == true
                 };
                 if (attr?.CustomType != null)
-                    field["customType"] = attr.CustomType; 
+                    field["customType"] = attr.CustomType;
+                if (attr?.Id != null)
+                    field["id"] = attr.Id;
                 if (nullable)
                     field["nullable"] = true;
                 if (listType != null)


### PR DESCRIPTION
Extend RemoteUiField attribute to allow override Id in schema (Useful when serialization field renamed via JsonProperty)