### PR TITLE
Unnecessary Id naming transformation

### DIFF
--- a/RemoteUi/RemoteUi.cs
+++ b/RemoteUi/RemoteUi.cs
@@ -264,7 +264,7 @@ namespace RemoteUi
             var groups = typee.GetCustomAttributes<RemoteUiFieldGroup>()
                 .Select(x => new FieldGroup
                 {
-                    Id = _namingStrategy.GetPropertyName(x.Id, false),
+                    Id = x.Id,
                     Name = x.Name
                 }).ToList();
 
@@ -372,7 +372,7 @@ namespace RemoteUi
                     {
                         lst.Add(new
                         {
-                            id = _namingStrategy.GetPropertyName(radioAttr.Id, false),
+                            id = radioAttr.Id,
                             name = radioAttr.Name
                         });
                     }
@@ -382,7 +382,7 @@ namespace RemoteUi
                         foreach (var kp in customAttr.Get(services))
                             lst.Add(new
                             {
-                                id = _namingStrategy.GetPropertyName(kp.Key, false),
+                                id = kp.Key,
                                 name = kp.Value
                             });
                     }
@@ -399,7 +399,7 @@ namespace RemoteUi
                     var grp = dic[extra.Group ?? ""];
                     var field = new JObject
                     {
-                        ["id"] = _namingStrategy.GetPropertyName(extra.Id, false),
+                        ["id"] = extra.Id,
                         ["name"] = extra.DisplayName,
                         ["type"] = extra.Type.ToString()
                     };
@@ -409,7 +409,7 @@ namespace RemoteUi
                         extra.Type.Equals(RemoteUiFieldType.Custom))
                         field["possibleValues"] = JToken.FromObject(extra.PossibleValues.Select(kp => new
                         {
-                            id = _namingStrategy.GetPropertyName(kp.Key, false),
+                            id = kp.Key,
                             name = kp.Value
                         }));
                     if (extra.Type.Equals(RemoteUiFieldType.List))


### PR DESCRIPTION
#7 adds unnecessary renames

This PR stay id for FieldGroup, Radio, List and CustomFields as is without transforming