### PR TITLE
Fix strict Typescript compilation errors

### DIFF
--- a/RemoteUi/web/src/RemoteUiEditor.tsx
+++ b/RemoteUi/web/src/RemoteUiEditor.tsx
@@ -421,7 +421,7 @@ interface CustomSelect {
 class RemoteUiEditorContext
 {
     @observable.ref remoteUiEditorCustomSelect?: CustomSelect;
-    @observable highlightErrors: boolean;
+    @observable highlightErrors: boolean = false;
     @observable.ref customization?: IRemoteUiEditorCustomization;
 }
 

--- a/RemoteUi/web/src/RemoteUiEditorStore.ts
+++ b/RemoteUi/web/src/RemoteUiEditorStore.ts
@@ -487,7 +487,7 @@ export class RemoteUiFileBase64Store implements IRemoteUiData {
     @observable useOldFile : boolean;
     @observable nullable : boolean;
     
-    @observable.ref file: File | null;
+    @observable.ref file: File | null = null;
     @observable isValid = true;
     getData() : Promise<any> | any
     {


### PR DESCRIPTION
Apparently, the Typescript compiler is complaining when including RemoteUi sources and compiling code in strict mode:

```sh
ERROR in [at-loader] ../../external/remoteui/RemoteUi/web/src/RemoteUiEditorStore.ts:490:21 
    TS2564: Property 'file' has no initializer and is not definitely assigned in the constructor.

ERROR in [at-loader] ../../external/remoteui/RemoteUi/web/src/RemoteUiEditor.tsx:424:17 
    TS2564: Property 'highlightErrors' has no initializer and is not definitely assigned in the constructor.
```

Let's resolve the issues!